### PR TITLE
Update path used for GitHub site Maven plugin

### DIFF
--- a/barchart-feed-ddf-assembly/pom.xml
+++ b/barchart-feed-ddf-assembly/pom.xml
@@ -183,10 +183,10 @@
 			<plugin>
       	  		<groupId>com.github.github</groupId>
       	  		<artifactId>site-maven-plugin</artifactId>
-      	  		<version>0.5</version>
+      	  		<version>0.6</version>
       	  		<configuration>
-        			<message>Creating site for ${project.version}</message>
-        			<path>barchart-feed-ddf/barchart-feed-ddf-assembly</path>
+        			<message>Creating site for ${project.artifactId} ${project.version}</message>
+        			<path>barchart-feed-ddf-assembly</path>
         			<merge>true</merge>
       	  		</configuration>
       	  		<executions>

--- a/barchart-feed-ddf-datalink/pom.xml
+++ b/barchart-feed-ddf-datalink/pom.xml
@@ -46,10 +46,10 @@
 			<plugin>
       	  		<groupId>com.github.github</groupId>
       	  		<artifactId>site-maven-plugin</artifactId>
-      	  		<version>0.5</version>
+      	  		<version>0.6</version>
       	  		<configuration>
-        			<message>Creating site for ${project.version}</message>
-        			<path>barchart-feed-ddf/barchart-feed-ddf-datalink</path>
+        			<message>Creating site for ${project.artifactId} ${project.version}</message>
+        			<path>barchart-feed-ddf-datalink</path>
         			<merge>true</merge>
       	  		</configuration>
       	  		<executions>

--- a/barchart-feed-ddf-historical/pom.xml
+++ b/barchart-feed-ddf-historical/pom.xml
@@ -46,10 +46,10 @@
 			<plugin>
       	  		<groupId>com.github.github</groupId>
       	  		<artifactId>site-maven-plugin</artifactId>
-      	  		<version>0.5</version>
+      	  		<version>0.6</version>
       	  		<configuration>
-        			<message>Creating site for ${project.version}</message>
-        			<path>barchart-feed-ddf/barchart-feed-ddf-historical</path>
+        			<message>Creating site for ${project.artifactId} ${project.version}</message>
+        			<path>barchart-feed-ddf-historical</path>
         			<merge>true</merge>
       	  		</configuration>
       	  		<executions>

--- a/barchart-feed-ddf-instrument/pom.xml
+++ b/barchart-feed-ddf-instrument/pom.xml
@@ -37,10 +37,10 @@
     	<plugin>
       	  <groupId>com.github.github</groupId>
       	  <artifactId>site-maven-plugin</artifactId>
-      	  <version>0.5</version>
+      	  <version>0.6</version>
       	  <configuration>
-        	<message>Creating site for ${project.version}</message>
-        	<path>barchart-feed-ddf/barchart-feed-ddf-instrument</path>
+        	<message>Creating site for ${project.artifactId} ${project.version}</message>
+        	<path>barchart-feed-ddf-instrument</path>
         	<merge>true</merge>
       	  </configuration>
       	  <executions>

--- a/barchart-feed-ddf-market/pom.xml
+++ b/barchart-feed-ddf-market/pom.xml
@@ -37,10 +37,10 @@
     	<plugin>
       	  <groupId>com.github.github</groupId>
       	  <artifactId>site-maven-plugin</artifactId>
-      	  <version>0.5</version>
+      	  <version>0.6</version>
       	  <configuration>
-        	<message>Creating site for ${project.version}</message>
-        	<path>barchart-feed-ddf/barchart-feed-ddf-market</path>
+        	<message>Creating site for ${project.artifactId} ${project.version}</message>
+        	<path>barchart-feed-ddf-market</path>
         	<merge>true</merge>
       	  </configuration>
       	  <executions>

--- a/barchart-feed-ddf-message/pom.xml
+++ b/barchart-feed-ddf-message/pom.xml
@@ -37,10 +37,10 @@
     	<plugin>
       	  <groupId>com.github.github</groupId>
       	  <artifactId>site-maven-plugin</artifactId>
-      	  <version>0.5</version>
+      	  <version>0.6</version>
       	  <configuration>
-        	<message>Creating site for ${project.version}</message>
-        	<path>barchart-feed-ddf/barchart-feed-ddf-message</path>
+        	<message>Creating site for ${project.artifactId} ${project.version}</message>
+        	<path>barchart-feed-ddf-message</path>
         	<merge>true</merge>
       	  </configuration>
       	  <executions>

--- a/barchart-feed-ddf-resolver/pom.xml
+++ b/barchart-feed-ddf-resolver/pom.xml
@@ -44,10 +44,10 @@
     	<plugin>
       	  <groupId>com.github.github</groupId>
       	  <artifactId>site-maven-plugin</artifactId>
-      	  <version>0.5</version>
+      	  <version>0.6</version>
       	  <configuration>
-        	<message>Creating site for ${project.version}</message>
-        	<path>barchart-feed-ddf/barchart-feed-ddf-resolver</path>
+        	<message>Creating site for ${project.artifactId} ${project.version}</message>
+        	<path>barchart-feed-ddf-resolver</path>
         	<merge>true</merge>
       	  </configuration>
       	  <executions>

--- a/barchart-feed-ddf-settings/pom.xml
+++ b/barchart-feed-ddf-settings/pom.xml
@@ -37,10 +37,10 @@
     	<plugin>
       	  <groupId>com.github.github</groupId>
       	  <artifactId>site-maven-plugin</artifactId>
-      	  <version>0.5</version>
+      	  <version>0.6</version>
       	  <configuration>
-        	<message>Creating site for ${project.version}</message>
-        	<path>barchart-feed-ddf/barchart-feed-ddf-settings</path>
+        	<message>Creating site for ${project.artifactId} ${project.version}</message>
+        	<path>barchart-feed-ddf-settings</path>
         	<merge>true</merge>
       	  </configuration>
       	  <executions>

--- a/barchart-feed-ddf-symbol/pom.xml
+++ b/barchart-feed-ddf-symbol/pom.xml
@@ -37,10 +37,10 @@
     	<plugin>
       	  <groupId>com.github.github</groupId>
       	  <artifactId>site-maven-plugin</artifactId>
-      	  <version>0.5</version>
+      	  <version>0.6</version>
       	  <configuration>
-        	<message>Creating site for ${project.version}</message>
-        	<path>barchart-feed-ddf/barchart-feed-ddf-symbol</path>
+        	<message>Creating site for ${project.artifactId} ${project.version}</message>
+        	<path>barchart-feed-ddf-symbol</path>
         	<merge>true</merge>
       	  </configuration>
       	  <executions>

--- a/barchart-feed-ddf-util/pom.xml
+++ b/barchart-feed-ddf-util/pom.xml
@@ -35,11 +35,10 @@
     	<plugin>
       	  <groupId>com.github.github</groupId>
       	  <artifactId>site-maven-plugin</artifactId>
-      	  <version>0.5</version>
+      	  <version>0.6</version>
       	  <configuration>
-        	<message>Creating site for ${project.version}</message>
-        	<repositoryName>barchart-feed-ddf/barchart-feed-ddf-util/</repositoryName>
-        	<repositoryOwner>barchart</repositoryOwner>
+        	<message>Creating site for ${project.artifactId} ${project.version}</message>
+        	<path>barchart-feed-ddf-util</path>
         	<merge>true</merge>
       	  </configuration>
       	  <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,10 @@
     	<plugin>
       	  <groupId>com.github.github</groupId>
       	  <artifactId>site-maven-plugin</artifactId>
-      	  <version>0.5</version>
+      	  <version>0.6</version>
       	  <configuration>
-        	<message>Creating site for ${project.version}</message>
-        	<includes>${barchart-feed-ddf-util}</includes>
+        	<message>Creating site for ${project.artifactId} ${project.version}</message>
+        	<merge>false</merge>
       	  </configuration>
       	  <executions>
         	<execution>


### PR DESCRIPTION
No prefix is needed, only the path of the module which
will be interpreted relative to the root of the site.

Also upgrades to the latest plugin version and includes
the artifact id of the site being generated in the commit
message.
